### PR TITLE
Catch RTSP session  crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The package can be installed by adding `rtsp` to your list of dependencies in `m
 ```elixir
 def deps do
   [
-    {:rtsp, "~> 0.3.2"}
+    {:rtsp, "~> 0.4.0"}
   ]
 end
 ```

--- a/lib/rtsp.ex
+++ b/lib/rtsp.ex
@@ -248,6 +248,11 @@ defmodule RTSP do
   end
 
   @impl true
+  def handle_info({:EXIT, _pid, _reason}, state) do
+    {:noreply, ConnectionManager.clean(state)}
+  end
+
+  @impl true
   def handle_info(msg, state) do
     Logger.warning("Received unexpected message: #{inspect(msg)}")
     {:noreply, state}

--- a/lib/rtsp/connection_manager.ex
+++ b/lib/rtsp/connection_manager.ex
@@ -42,13 +42,8 @@ defmodule RTSP.ConnectionManager do
       error ->
         error
     end
-  rescue
-    reason ->
-      Logger.error("""
-      ConnectionManager: RTSP session crashed
-      Reason: #{inspect(reason)}
-      """)
-
+  catch
+    :exit, _reason ->
       {:error, :session_crashed}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -63,15 +63,19 @@ defmodule RTSP.MixProject do
         "LICENSE"
       ],
       nest_modules_by_prefix: [
-        RTSP.RTP.Encoder,
-        RTSP.RTP.Decoder
+        RTSP.RTP
       ],
       groups_for_modules: [
+        "RTP": [
+          RTSP.RTP.Encoder,
+          RTSP.RTP.Decoder,
+          RTSP.RTP.PacketReorderer
+        ],
         "RTP Encoders": [
           ~r/RTSP\.RTP\.Encoder($|\.)/
         ],
         "RTP Decoders": [
-          ~r/RTSP\.RTP\.Decoder($|\.)/
+          ~r/RTSP\.RTP\.Decoder($|\.)/,
         ],
         "RTP Extensions": [
           RTSP.RTP.OnvifReplayExtension

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule RTSP.MixProject do
   use Mix.Project
 
-  @version "0.3.2"
+  @version "0.4.0"
   @github_url "https://github.com/gBillal/rtsp"
 
   def project do


### PR DESCRIPTION
When streaming with tcp, the session may read some media data along the PLAY request which crashes the session. We catch it and re-initialize the session.