### PR TITLE
Fix file server inner handler initialization

### DIFF
--- a/lib/rtsp/file_server/file_reader/mp4.ex
+++ b/lib/rtsp/file_server/file_reader/mp4.ex
@@ -127,8 +127,13 @@ if Code.ensure_loaded?(ExMP4) do
       }
     end
 
-    defp fmtp(%{media: :av1}, pt) do
-      %ExSDP.Attribute.FMTP{pt: pt}
+    defp fmtp(%{media: :av1} = track, pt) do
+      %ExSDP.Attribute.FMTP{
+        pt: pt,
+        profile: track.priv_data.seq_profile,
+        level_idx: track.priv_data.seq_level_idx_0,
+        tier: track.priv_data.seq_tier_0
+      }
     end
 
     defp fmtp(%{media: :aac} = track, pt) do

--- a/lib/rtsp/server/inner_handler.ex
+++ b/lib/rtsp/server/inner_handler.ex
@@ -114,7 +114,3 @@ defmodule RTSP.Server.InnerHandler do
     end)
   end
 end
-
-defmodule TestHandler do
-  use RTSP.Server.ClientHandler
-end

--- a/lib/rtsp/server/inner_handler.ex
+++ b/lib/rtsp/server/inner_handler.ex
@@ -12,17 +12,19 @@ defmodule RTSP.Server.InnerHandler do
 
   @impl true
   def init(config) do
-    {:ok, client_session} = ClientSession.start_link(config)
-
     %{
       path: nil,
-      client_session: client_session,
+      config: config,
+      client_session: nil,
       recbuf: config[:udp_recbuf_size] || @udp_recbuf_size
     }
   end
 
   @impl true
-  def handle_open_connection(_socket, state), do: state
+  def handle_open_connection(_socket, state) do
+    {:ok, client_session} = ClientSession.start_link(state.config)
+    %{state | client_session: client_session}
+  end
 
   @impl true
   def handle_describe(_request, state) do
@@ -111,4 +113,8 @@ defmodule RTSP.Server.InnerHandler do
       end)
     end)
   end
+end
+
+defmodule TestHandler do
+  use RTSP.Server.ClientHandler
 end


### PR DESCRIPTION
The `init` callback of `Membrane.Server.Handler` is only called once when the server start. We need to use `handle_open_connection` to have state per client.`