### PR TITLE
Clean all processes on crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,3 @@ end
 | [Opus](https://datatracker.ietf.org/doc/html/rfc7587)  |  ✔️        |  ✔️          |
 | Vorbis|           |             |
 | AC-3  |           |             |
-

--- a/lib/rtsp.ex
+++ b/lib/rtsp.ex
@@ -132,6 +132,11 @@ defmodule RTSP do
     GenServer.start_link(__MODULE__, opts, name: opts[:name])
   end
 
+  def start(opts) do
+    opts = Keyword.put_new(opts, :receiver, self())
+    GenServer.start(__MODULE__, opts, name: opts[:name])
+  end
+
   @doc """
   Connects the rtsp server.
 
@@ -227,33 +232,13 @@ defmodule RTSP do
   end
 
   @impl true
-  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    state =
-      cond do
-        pid == state.tcp_receiver ->
-          notify_closed_session(state)
-          ConnectionManager.clean(%{state | tcp_receiver: nil})
-
-        pid in state.udp_receivers ->
-          case List.delete(state.udp_receivers, pid) do
-            [] ->
-              notify_closed_session(state)
-              ConnectionManager.clean(%{state | udp_receivers: []})
-
-            receivers ->
-              %{state | udp_receivers: receivers}
-          end
-
-        true ->
-          ConnectionManager.clean(state)
-      end
-
-    {:noreply, state}
-  end
-
-  @impl true
-  def handle_info({:EXIT, _pid, _reason}, state) do
-    {:noreply, ConnectionManager.clean(state)}
+  def handle_info({:EXIT, pid, _reason}, state) do
+    if state.rtsp_session == pid or state.tcp_receiver == pid or pid in state.udp_receivers do
+      notify_closed_session(state)
+      {:noreply, ConnectionManager.clean(state)}
+    else
+      {:noreply, state}
+    end
   end
 
   @impl true
@@ -272,12 +257,11 @@ defmodule RTSP do
       onvif_replay: state.onvif_replay != []
     ]
 
-    {:ok, pid} = TCPReceiver.start(options)
+    {:ok, pid} = TCPReceiver.start_link(options)
 
     :ok = :inet.setopts(state.socket, buffer: @initial_recv_buffer, active: 100)
     :ok = Membrane.RTSP.transfer_socket_control(state.rtsp_session, pid)
 
-    Process.monitor(pid)
     %{state | tcp_receiver: pid}
   end
 
@@ -293,9 +277,7 @@ defmodule RTSP do
         server_ip: server_ip
       ]
 
-      {:ok, pid} = UDPReceiver.start(opts)
-
-      Process.monitor(pid)
+      {:ok, pid} = UDPReceiver.start_link(opts)
       pid
     end)
     |> then(&%{state | udp_receivers: &1})

--- a/lib/rtsp/connection_manager.ex
+++ b/lib/rtsp/connection_manager.ex
@@ -81,8 +81,17 @@ defmodule RTSP.ConnectionManager do
     if state.rtsp_session, do: Membrane.RTSP.close(state.rtsp_session)
     if state.keep_alive_timer, do: Process.cancel_timer(state.keep_alive_timer)
     if state.check_recbuf_timer, do: Process.cancel_timer(state.check_recbuf_timer)
+    if state.tcp_receiver, do: RTSP.TCPReceiver.stop(state.tcp_receiver)
+    Enum.each(state.udp_receivers, &RTSP.UDPReceiver.stop/1)
 
-    %{state | state: :init, rtsp_session: nil, keep_alive_timer: nil}
+    %{
+      state
+      | state: :init,
+        rtsp_session: nil,
+        keep_alive_timer: nil,
+        udp_receivers: [],
+        tcp_receiver: nil
+    }
   end
 
   @spec get_server_ip(State.t()) :: :inet.ip_address() | nil

--- a/lib/rtsp/rtp/decoder/h264.ex
+++ b/lib/rtsp/rtp/decoder/h264.ex
@@ -49,7 +49,7 @@ defmodule RTSP.RTP.Decoder.H264 do
   defp maybe_strip_prefix(nalu), do: nalu
 
   # depayloader
-  defp depayload(packet, state) do
+  defp depayload(packet, %State{} = state) do
     with {:ok, {header, _payload} = nal} <- NAL.Header.parse_unit_header(packet.payload),
          unit_type = NAL.Header.decode_type(header),
          {:ok, nalus, state} <- handle_unit_type(unit_type, nal, packet, state) do
@@ -134,7 +134,7 @@ defmodule RTSP.RTP.Decoder.H264 do
 
   defp update_parameter_sets([], [], state), do: state
 
-  defp update_parameter_sets(sps, pps, state) do
+  defp update_parameter_sets(sps, pps, %State{} = state) do
     sps = Map.new(sps, &{NALU.SPS.id(&1), &1})
 
     pps =

--- a/lib/rtsp/rtp/decoder/h265.ex
+++ b/lib/rtsp/rtp/decoder/h265.ex
@@ -61,7 +61,7 @@ defmodule RTSP.RTP.Decoder.H265 do
     {:ok, {[packet.payload], packet.timestamp, packet.marker}, state}
   end
 
-  defp handle_unit_type(:fu, {header, data}, packet, state) do
+  defp handle_unit_type(:fu, {header, data}, packet, %State{} = state) do
     case FU.parse(data, packet.sequence_number, map_state_to_fu(state)) do
       {:ok, {data, type, _don}} ->
         data = [<<0::1, type::6, header.nuh_layer_id::6, header.nuh_temporal_id_plus1::3>> | data]
@@ -130,7 +130,7 @@ defmodule RTSP.RTP.Decoder.H265 do
 
   defp update_parameter_sets([], [], [], state), do: state
 
-  defp update_parameter_sets(vps, sps, pps, state) do
+  defp update_parameter_sets(vps, sps, pps, %State{} = state) do
     vps = Map.new(vps, &{NALU.VPS.id(&1), &1})
     sps = Map.new(sps, &{NALU.SPS.id(&1), &1})
 

--- a/lib/rtsp/tcp_receiver.ex
+++ b/lib/rtsp/tcp_receiver.ex
@@ -45,12 +45,26 @@ defmodule RTSP.TCPReceiver do
     GenServer.start(__MODULE__, opts)
   end
 
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  def stop(pid) do
+    GenServer.cast(pid, :terminate)
+  end
+
   @impl true
   def init(options) do
     state = struct!(State, options)
     state = %{state | last_timestamp: System.monotonic_time(:millisecond)}
     Process.send_after(self(), :check_idle, 2_000)
     {:ok, state}
+  end
+
+  @impl true
+  def handle_cast(:terminate, state) do
+    :gen_tcp.close(state.socket)
+    {:stop, :normal, state}
   end
 
   @impl true

--- a/lib/rtsp/udp_receiver.ex
+++ b/lib/rtsp/udp_receiver.ex
@@ -19,7 +19,7 @@ defmodule RTSP.UDPReceiver do
 
   @spec stop(pid()) :: :ok
   def stop(pid) do
-    GenServer.stop(pid, :normal)
+    GenServer.cast(pid, :terminate)
   end
 
   @impl true
@@ -44,6 +44,12 @@ defmodule RTSP.UDPReceiver do
     send_empty_packets(socket, rtcp_socket, options[:server_ip], track.server_port)
 
     {:ok, state}
+  end
+
+  @impl true
+  def handle_cast(:terminate, state) do
+    :gen_udp.close(state.socket)
+    {:stop, :normal, state}
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule RTSP.MixProject do
   use Mix.Project
 
-  @version "0.8.1"
+  @version "0.8.2"
   @github_url "https://github.com/gBillal/rtsp"
 
   def project do

--- a/test/rtsp/rtsp_test.exs
+++ b/test/rtsp/rtsp_test.exs
@@ -102,6 +102,82 @@ defmodule RTSPTest do
     ExMP4.Reader.close(reader)
   end
 
+  describe "Processes crash" do
+    test "clean processes after rtsp session crash", %{port: server_port} do
+      url = "rtsp://127.0.0.1:#{server_port}/hevc_opus"
+      {:ok, client_pid} = RTSP.start_link(stream_uri: url, allowed_media_types: [:video])
+      {:ok, _} = RTSP.connect(client_pid)
+      :ok = RTSP.play(client_pid)
+
+      state = :sys.get_state(client_pid)
+      assert Process.alive?(state.rtsp_session)
+      assert Process.alive?(state.tcp_receiver)
+
+      Process.exit(state.rtsp_session, :kill)
+
+      assert_receive {:rtsp, ^client_pid, :session_closed}
+      Process.sleep(10)
+      refute Process.alive?(state.tcp_receiver)
+    end
+
+    test "clean processes after tcp receiver crash", %{port: server_port} do
+      url = "rtsp://127.0.0.1:#{server_port}/hevc_opus"
+      {:ok, client_pid} = RTSP.start_link(stream_uri: url, allowed_media_types: [:video])
+      {:ok, _} = RTSP.connect(client_pid)
+      :ok = RTSP.play(client_pid)
+
+      state = :sys.get_state(client_pid)
+      assert Process.alive?(state.rtsp_session)
+      assert Process.alive?(state.tcp_receiver)
+
+      Process.exit(state.tcp_receiver, :kill)
+
+      assert_receive {:rtsp, ^client_pid, :session_closed}
+      refute Process.alive?(state.tcp_receiver)
+      refute Process.alive?(state.rtsp_session)
+    end
+
+    test "clean processes after udp receiver crash", %{port: server_port} do
+      url = "rtsp://127.0.0.1:#{server_port}/hevc_opus"
+
+      {:ok, client_pid} =
+        RTSP.start_link(
+          stream_uri: url,
+          allowed_media_types: [:video],
+          transport: {:udp, 10_000, 20_000}
+        )
+
+      {:ok, _} = RTSP.connect(client_pid)
+      :ok = RTSP.play(client_pid)
+
+      state = :sys.get_state(client_pid)
+      assert state.udp_receivers != []
+      assert Enum.all?(state.udp_receivers, &Process.alive?/1)
+
+      Process.exit(List.first(state.udp_receivers), :kill)
+
+      assert_receive {:rtsp, ^client_pid, :session_closed}
+      refute Enum.any?(state.udp_receivers, &Process.alive?/1)
+      Process.sleep(10)
+      refute Process.alive?(state.rtsp_session)
+    end
+
+    test "clean processes after client crashes", %{port: server_port} do
+      url = "rtsp://127.0.0.1:#{server_port}/hevc_opus"
+      {:ok, client_pid} = RTSP.start(stream_uri: url, allowed_media_types: [:video])
+      {:ok, _} = RTSP.connect(client_pid)
+      :ok = RTSP.play(client_pid)
+
+      state = :sys.get_state(client_pid)
+
+      Process.exit(client_pid, :kill)
+
+      Process.sleep(10)
+      refute Process.alive?(state.rtsp_session)
+      refute Process.alive?(state.tcp_receiver)
+    end
+  end
+
   for {path, fixture} <- @paths do
     describe "stream video & audio: #{path}" do
       test "use TCP", ctx do


### PR DESCRIPTION
A better clean up on process crash:

- Stop rtsp session
- Stop tcp receiver if any
- Stop udp receivers if any.